### PR TITLE
Add apply to mobile and desktop navbars

### DIFF
--- a/website/src/app/components/Navbar/Nav.css
+++ b/website/src/app/components/Navbar/Nav.css
@@ -44,7 +44,7 @@ nav {
 }
 
 .elem {
-  margin: 0 70px 0 70px;
+  margin: 0 35px;
   white-space: nowrap;
 }
 

--- a/website/src/app/components/Navbar/Nav.js
+++ b/website/src/app/components/Navbar/Nav.js
@@ -87,7 +87,7 @@ function Nav() {
           </div>
         </animated.div>
         <animated.div style={slideDown} className="nav-bar">
-          <div className="left">
+          <div>
             <Link to="/">
               <img className="logo" src={ctcLogo} alt="Commit the Change logo" />
             </Link>

--- a/website/src/app/components/Navbar/Nav.js
+++ b/website/src/app/components/Navbar/Nav.js
@@ -57,6 +57,14 @@ function Nav() {
                 }}
                 to="/contact"
               >
+                Contact Us
+              </Link>
+              <Link
+                onClick={() => {
+                  toggleVisibility(false);
+                }}
+                to="/apply"
+              >
                 Apply Now
               </Link>
             </div>
@@ -96,9 +104,14 @@ function Nav() {
               </Link>
             </li>
             <li>
+              <Link to="/contact" className="elem">
+                Contact Us
+              </Link>
+            </li>
+            <li>
               <button type="button" className="elem apply-button">
-                <Link to="/contact" id="apply-link">
-                  Contact Us
+                <Link to="/apply" id="apply-link">
+                  Apply
                 </Link>
               </button>
             </li>


### PR DESCRIPTION
Adds "Apply" link to nav bar.
For desktop navbar, replaced link and text of "Contact Us" with "Apply". Contact link has now moved to navbar.

![Screenshot_20210910_144853](https://user-images.githubusercontent.com/15023712/132921254-3d73e724-712a-4f74-8526-72a73ee91431.png)
